### PR TITLE
Remove guarantee

### DIFF
--- a/specs/index.md
+++ b/specs/index.md
@@ -173,7 +173,7 @@ plans:
 
 ### 11. Plans application
 
-First `base` keyword is proposed as the common base plan. All limits and guaraties applied to base applies to all plans.
+First `base` keyword is proposed as the common base plan. All limits in base plan apply to all plans.
 
 Then, a specific plan inherits definitions from `base` and can override any limit to make it more concrete or relaxed.
 

--- a/specs/index.md
+++ b/specs/index.md
@@ -63,10 +63,6 @@ metrics:
   requests:
     type: "int64"
     description: "Number of requests"
-  responseTimeMs:
-    type: "double"
-    unit: "ms"
-    description: "Response time in milliseconds"
 ```
 
 Metrics sections describes the relevant tecnical indcators and business metrics for the SLA.

--- a/specs/index.md
+++ b/specs/index.md
@@ -56,21 +56,17 @@ metrics:
     type: integer
     format: int64
     description: Number of different animal types.
-    resolution: check
   resourceInstances:
     type: integer
     format: int64
     description: Number of pet resources
-    resolution: consumption
   requests:
     type: "int64"
     description: "Number of requests"
-    resolution: consumption
   responseTimeMs:
     type: "double"
     unit: "ms"
     description: "Response time in milliseconds"
-    resolution: consumption
 ```
 
 Metrics sections describes the relevant tecnical indcators and business metrics for the SLA.
@@ -81,10 +77,6 @@ For each metric to be defined:
 
 - `type` and `format` describes the data-type following same conventions as OpenAPI 3.x.
 - `description` provides a label for the metric been defined.
-- `resolution` could be `check` or `consumption` (_optional_).
-  - `check` is a precondition that can be evaluated before granting permission for the service (no need to evaluate the payload).
-  - `consumption` is a check that needs to inspect the message to decide if limits will be overpassed or not. 
-
 - `unit` (when applicable) describes the units to be used for the measure. e.g. `ms`, `req/s`, etc.
 
 ### 5. Pricing

--- a/specs/index.md
+++ b/specs/index.md
@@ -134,26 +134,6 @@ rates:
           period: secondly
 ```
 
-Samples:
-
-- maximum 1 request per second to `GET /pets/{id}`
-
-```yaml
-guarantees:
-  global:
-    global:
-      - objective: responseTimeMs <= 800
-        period: daily
-        window: dynamic
-```
-
-### 9. Guarantees
-
-Description of the API warranties commitment by the service provider.
-
-Example:
-
-- main objective: response time under 800 ms (measured daily).
 
 ### 10. Plans
 
@@ -193,12 +173,6 @@ plans:
             - max: 500
           animalTypes:
             - max: 5
-    guarantees:
-      global:
-        global:
-          - objective: responseTimeMs <= 250
-            period: daily
-            window: dynamic
 ```
 
 ### 11. Plans application
@@ -210,7 +184,6 @@ Then, a specific plan inherits definitions from `base` and can override any limi
 ### 12. Keywords
 
 - `base` is used as the common properties applicable to all plans (can be overriden).
-- `global` is used in the guarantees section to describe API common guarantiees (cab be overriden by specific plans).
 
 ## References
 


### PR DESCRIPTION
In order to simplify this minimal spec, perhaps we need to address "guarantee" in a further version since the proposed structure was too simplistic to be realistic (e.g. responseTime is typically expressed in terms of an statistic operator such as "average" over a certain period and those aspects weren't clear in the definition) 